### PR TITLE
feat: デフォルト解像度を1920x1080に変更

### DIFF
--- a/src/lib/p5-wrapper.js
+++ b/src/lib/p5-wrapper.js
@@ -4,8 +4,8 @@
 
 export default class P5 extends p5{
   constructor ({
-    width = window.innerWidth,
-    height = window.innerHeight,
+    width = 1920,
+    height = 1080,
     mode = 'P2D'
   } = {}) {
     //console.log('createing canvas', width, height, window.innerWidth, window.innerHeight)

--- a/src/views/EditorCm6.js
+++ b/src/views/EditorCm6.js
@@ -49,7 +49,7 @@ export default class Editor extends Component {
     return false
   }
 
-  createElement ({ width = window.innerWidth, height = window.innerHeight} = {}) {
+  createElement ({ width = 1920, height = 1080} = {}) {
     this.textEl = html` <div></div>`
     this.logElement = html`<div class="console cm-s-tomorrow-night-eighties"></div>`
     return html`<div id="editor-container" style="display:flex;flex-direction:column;">

--- a/src/views/EditorComponent.js
+++ b/src/views/EditorComponent.js
@@ -48,7 +48,7 @@ export default class Editor extends Component {
     return false
   }
 
-  createElement ({ width = window.innerWidth, height = window.innerHeight} = {}) {
+  createElement ({ width = 1920, height = 1080} = {}) {
     this.textEl = html` <textarea></textarea>`
     this.logElement = html`<div class="console cm-s-tomorrow-night-eighties"></div>`
     return html`<div id="editor-container" style="display:flex;flex-direction:column;">

--- a/src/views/Hydra.js
+++ b/src/views/Hydra.js
@@ -58,7 +58,7 @@ export default class HydraCanvas extends Component {
     return false
   }
 
-  createElement({ width = window.innerWidth, height = window.innerHeight } = {}) {
+  createElement({ width = 1920, height = 1080 } = {}) {
 
     return html`<div style="width:100%;height:100%;">
         <canvas id="hydra-canvas" class="bg-black" style="image-rendering:pixelated; width:100%;height:100%" width="${width}" height="${height}"></canvas></div>`


### PR DESCRIPTION
デフォルト解像度を動的なウィンドウサイズから1920x1080に変更しました。

## 変更されたファイル:
- src/views/Hydra.js
- src/lib/p5-wrapper.js
- src/views/EditorCm6.js
- src/views/EditorComponent.js

Resolves #3

🤖 Generated with [Claude Code](https://claude.ai/code)