### PR TITLE
feat: detect YouTube player seek and sync Hydra playback position

### DIFF
--- a/src/lib/youtube-player.js
+++ b/src/lib/youtube-player.js
@@ -132,6 +132,17 @@ class YouTubePlayerWrapper {
   }
 
   /**
+   * 動画の長さを取得
+   * @returns {number} 動画の長さ（秒）。広告再生中は広告の長さを返す可能性がある
+   */
+  getDuration() {
+    if (this.player && this.isReady) {
+      return this.player.getDuration()
+    }
+    return 0
+  }
+
+  /**
    * プレーヤーの状態を取得
    * @returns {number} PlayerState (-1:未開始, 0:終了, 1:再生中, 2:一時停止, 3:バッファリング, 5:キュー済み)
    */

--- a/src/stores/performance-store.js
+++ b/src/stores/performance-store.js
@@ -577,8 +577,8 @@ export default function performanceStore(state, emitter) {
     emitter.emit('editor: load code', snapshot.code)
     emitter.emit('repl: eval', snapshot.code)
 
-    // YouTubeシーク
-    if (snapshot.youtubeTime !== undefined) {
+    // YouTubeシーク（YouTube側からのseek時は不要 → 無限ループ防止）
+    if (snapshot.youtubeTime !== undefined && !state.performance._seekFromYoutube) {
       emitter.emit('youtube: sync seek', snapshot.youtubeTime)
     }
 
@@ -600,6 +600,45 @@ export default function performanceStore(state, emitter) {
 
     console.log(`[Performance] Seeked to snapshot ${index}`)
     emitter.emit('render')
+  })
+
+  // YouTube時刻から最も近いスナップショットへseek
+  emitter.on('performance: seek to youtube time', (youtubeTime) => {
+    if (!state.performance.isPlaying && !state.performance.isPaused) return
+
+    const sessionId = state.performance.playbackSessionId
+    const session = storage.getSession(sessionId)
+    if (!session) return
+
+    // youtubeTimeを持つスナップショットから最も近いものを探す
+    let bestIndex = -1
+    let bestDiff = Infinity
+
+    for (let i = 0; i < session.snapshots.length; i++) {
+      const snap = session.snapshots[i]
+      if (snap.youtubeTime === undefined || snap.youtubeTime === null) continue
+      const diff = Math.abs(snap.youtubeTime - youtubeTime)
+      if (diff < bestDiff) {
+        bestDiff = diff
+        bestIndex = i
+      }
+    }
+
+    if (bestIndex === -1) {
+      console.warn('[Performance] No snapshot with youtubeTime found')
+      return
+    }
+
+    // 現在と同じスナップショットなら何もしない
+    const currentIndex = state.performance.playbackIndex - 1
+    if (bestIndex === currentIndex) return
+
+    console.log(`[Performance] YouTube seek → snapshot ${bestIndex} (youtubeTime: ${session.snapshots[bestIndex].youtubeTime.toFixed(1)}s, target: ${youtubeTime.toFixed(1)}s)`)
+
+    // 既存のseek to snapshotを使用（ただしYouTube sync seekは不要なのでフラグで制御）
+    state.performance._seekFromYoutube = true
+    emitter.emit('performance: seek to snapshot', bestIndex)
+    state.performance._seekFromYoutube = false
   })
 
   // セッション削除

--- a/src/stores/youtube-store.js
+++ b/src/stores/youtube-store.js
@@ -83,8 +83,68 @@ export default function youtubeStore(state, emitter) {
     showUrlInput: false,
 
     // 双方向同期用（無限ループ防止）
-    ignoringStateChange: false
+    ignoringStateChange: false,
+
+    // YouTube側seekの検知用
+    seekDetectionTimerId: null,
+    lastPolledTime: null,
+    lastPollTimestamp: null,
+    ignoringSeek: false
   }
+
+  // YouTube側seekの検知ポーリングを開始
+  const SEEK_POLL_INTERVAL = 300 // ms
+  const SEEK_THRESHOLD = 2.0 // 秒: この差以上ならseekと判定
+
+  function startSeekDetection() {
+    stopSeekDetection()
+    state.youtube.lastPolledTime = youtubePlayer.getCurrentTime()
+    state.youtube.lastPollTimestamp = Date.now()
+
+    state.youtube.seekDetectionTimerId = setInterval(() => {
+      if (!state.youtube.isReady) return
+      if (state.youtube.ignoringSeek) return
+
+      const currentTime = youtubePlayer.getCurrentTime()
+      const now = Date.now()
+      const elapsedSec = (now - state.youtube.lastPollTimestamp) / 1000
+
+      // 再生中の場合: 期待される時刻との差でseekを検知
+      // 一時停止中の場合: 前回の時刻との差でseekを検知
+      const playerState = youtubePlayer.getPlayerState()
+      const isPlaying = playerState === 1
+      const expectedTime = isPlaying
+        ? state.youtube.lastPolledTime + elapsedSec
+        : state.youtube.lastPolledTime
+
+      const timeDiff = Math.abs(currentTime - expectedTime)
+
+      if (timeDiff > SEEK_THRESHOLD) {
+        console.log(`[YouTube] Seek detected: ${expectedTime.toFixed(1)}s → ${currentTime.toFixed(1)}s (diff: ${timeDiff.toFixed(1)}s)`)
+        emitter.emit('youtube: on user seek', currentTime)
+      }
+
+      state.youtube.lastPolledTime = currentTime
+      state.youtube.lastPollTimestamp = now
+    }, SEEK_POLL_INTERVAL)
+  }
+
+  function stopSeekDetection() {
+    if (state.youtube.seekDetectionTimerId) {
+      clearInterval(state.youtube.seekDetectionTimerId)
+      state.youtube.seekDetectionTimerId = null
+    }
+    state.youtube.lastPolledTime = null
+    state.youtube.lastPollTimestamp = null
+  }
+
+  // YouTube側でユーザーがseekした場合 → Hydra側をseek
+  emitter.on('youtube: on user seek', (youtubeTime) => {
+    if (state.youtube.syncMode !== 'playback') return
+
+    console.log(`[YouTube] Syncing Hydra to YouTube time: ${youtubeTime.toFixed(1)}s`)
+    emitter.emit('performance: seek to youtube time', youtubeTime)
+  })
 
   // YouTube URLを設定して動画を読み込み
   emitter.on('youtube: load video', async (url) => {
@@ -181,6 +241,7 @@ export default function youtubeStore(state, emitter) {
     state.youtube.syncMode = 'none'
     state.youtube.baseTime = null
     state.youtube.baseYoutubeTime = null
+    stopSeekDetection()
   })
 
   // 再生開始時にYouTube状態を同期
@@ -220,6 +281,12 @@ export default function youtubeStore(state, emitter) {
         youtubePlayer.seekTo(startTime)
         youtubePlayer.play()
         console.log('[YouTube] Playback started at', startTime)
+
+        // seek検知ポーリングを開始
+        // 少し待ってから開始（seekTo直後の時刻変動を避ける）
+        setTimeout(() => {
+          startSeekDetection()
+        }, 1000)
       } catch (e) {
         console.error('[YouTube] Failed to start playback:', e)
       }
@@ -234,6 +301,10 @@ export default function youtubeStore(state, emitter) {
       // 無限ループ防止フラグを立てる
       state.youtube.ignoringStateChange = true
       youtubePlayer.pause()
+      // 一時停止中もseek検知は継続（一時停止中にユーザーがseekする可能性がある）
+      // ただしlastPolledTimeを更新してfalse positiveを防ぐ
+      state.youtube.lastPolledTime = youtubePlayer.getCurrentTime()
+      state.youtube.lastPollTimestamp = Date.now()
       // 少し待ってからフラグを解除
       setTimeout(() => {
         state.youtube.ignoringStateChange = false
@@ -247,18 +318,28 @@ export default function youtubeStore(state, emitter) {
       // 無限ループ防止フラグを立てる
       state.youtube.ignoringStateChange = true
       youtubePlayer.play()
-      // 少し待ってからフラグを解除
+      // ポーリングのタイミング情報をリセット
       setTimeout(() => {
+        state.youtube.lastPolledTime = youtubePlayer.getCurrentTime()
+        state.youtube.lastPollTimestamp = Date.now()
         state.youtube.ignoringStateChange = false
       }, 100)
     }
   })
 
-  // シーク時の同期
+  // シーク時の同期（Hydra側 → YouTube）
   emitter.on('youtube: sync seek', (youtubeTime) => {
     if (state.youtube.syncMode === 'playback' && youtubeTime !== undefined && youtubeTime !== null) {
+      // 無限ループ防止: Hydra→YouTube seekをポーリングが検知しないようにする
+      state.youtube.ignoringSeek = true
       youtubePlayer.seekTo(youtubeTime)
       youtubePlayer.play()
+      // ポーリングのタイミング情報もリセット
+      setTimeout(() => {
+        state.youtube.lastPolledTime = youtubePlayer.getCurrentTime()
+        state.youtube.lastPollTimestamp = Date.now()
+        state.youtube.ignoringSeek = false
+      }, 500)
     }
   })
 
@@ -272,6 +353,7 @@ export default function youtubeStore(state, emitter) {
 
   // 動画をクリア
   emitter.on('youtube: clear', () => {
+    stopSeekDetection()
     youtubePlayer.destroy()
     state.youtube.isReady = false
     state.youtube.videoId = null
@@ -283,6 +365,7 @@ export default function youtubeStore(state, emitter) {
 
   // 破棄
   emitter.on('youtube: destroy', () => {
+    stopSeekDetection()
     youtubePlayer.destroy()
     state.youtube.isReady = false
     state.youtube.videoId = null

--- a/src/stores/youtube-store.js
+++ b/src/stores/youtube-store.js
@@ -48,6 +48,11 @@ export default function youtubeStore(state, emitter) {
       return
     }
 
+    // 広告による一時停止中はユーザー操作のpause/resumeを無視
+    if (state.youtube.pausedByAd) {
+      return
+    }
+
     // YouTube側で一時停止された場合 → セッション再生も一時停止
     if (event.data === 2 && prevState === 1) {
       console.log('[YouTube] Paused by user, pausing session playback')
@@ -90,7 +95,10 @@ export default function youtubeStore(state, emitter) {
     lastPolledTime: null,
     lastPollTimestamp: null,
     ignoringSeek: false,
-    videoDuration: 0
+    videoDuration: 0,
+
+    // 広告による一時停止中フラグ
+    pausedByAd: false
   }
 
   // YouTube側seekの検知ポーリングを開始
@@ -109,15 +117,36 @@ export default function youtubeStore(state, emitter) {
       if (state.youtube.ignoringSeek) return
 
       // 広告検知: getDuration()が本編と大きく異なる場合は広告再生中
-      // 広告中はgetCurrentTime()が広告の経過時間を返すため、seek検知をスキップ
       const currentDuration = youtubePlayer.getDuration()
-      if (state.youtube.videoDuration > 0 && currentDuration > 0 &&
-          Math.abs(currentDuration - state.youtube.videoDuration) > 5) {
-        // durationが変わった → 広告再生中の可能性、スキップ
-        console.log(`[YouTube] Ad detected (duration changed: ${state.youtube.videoDuration.toFixed(0)}s → ${currentDuration.toFixed(0)}s), skipping seek detection`)
+      const isAdPlaying = state.youtube.videoDuration > 0 && currentDuration > 0 &&
+          Math.abs(currentDuration - state.youtube.videoDuration) > 5
+
+      if (isAdPlaying) {
+        // 広告開始 → セッション一時停止
+        if (!state.youtube.pausedByAd) {
+          state.youtube.pausedByAd = true
+          console.log(`[YouTube] Ad started (duration: ${state.youtube.videoDuration.toFixed(0)}s → ${currentDuration.toFixed(0)}s), pausing session`)
+          state.youtube.ignoringStateChange = true
+          emitter.emit('performance: pause playback')
+          setTimeout(() => { state.youtube.ignoringStateChange = false }, 100)
+        }
         state.youtube.lastPollTimestamp = Date.now()
         return
       }
+
+      // 広告終了 → セッション再開
+      if (state.youtube.pausedByAd) {
+        state.youtube.pausedByAd = false
+        console.log('[YouTube] Ad ended, resuming session')
+        // ポーリング基準をリセットしてからセッション再開
+        state.youtube.lastPolledTime = youtubePlayer.getCurrentTime()
+        state.youtube.lastPollTimestamp = Date.now()
+        state.youtube.ignoringStateChange = true
+        emitter.emit('performance: resume playback')
+        setTimeout(() => { state.youtube.ignoringStateChange = false }, 100)
+        return
+      }
+
       // 広告終了後にdurationが戻った場合、記録を更新
       if (currentDuration > 0 && state.youtube.videoDuration === 0) {
         state.youtube.videoDuration = currentDuration

--- a/src/stores/youtube-store.js
+++ b/src/stores/youtube-store.js
@@ -89,7 +89,8 @@ export default function youtubeStore(state, emitter) {
     seekDetectionTimerId: null,
     lastPolledTime: null,
     lastPollTimestamp: null,
-    ignoringSeek: false
+    ignoringSeek: false,
+    videoDuration: 0
   }
 
   // YouTube側seekの検知ポーリングを開始
@@ -100,10 +101,27 @@ export default function youtubeStore(state, emitter) {
     stopSeekDetection()
     state.youtube.lastPolledTime = youtubePlayer.getCurrentTime()
     state.youtube.lastPollTimestamp = Date.now()
+    // 動画本編のdurationを記録（広告検知用）
+    state.youtube.videoDuration = youtubePlayer.getDuration()
 
     state.youtube.seekDetectionTimerId = setInterval(() => {
       if (!state.youtube.isReady) return
       if (state.youtube.ignoringSeek) return
+
+      // 広告検知: getDuration()が本編と大きく異なる場合は広告再生中
+      // 広告中はgetCurrentTime()が広告の経過時間を返すため、seek検知をスキップ
+      const currentDuration = youtubePlayer.getDuration()
+      if (state.youtube.videoDuration > 0 && currentDuration > 0 &&
+          Math.abs(currentDuration - state.youtube.videoDuration) > 5) {
+        // durationが変わった → 広告再生中の可能性、スキップ
+        console.log(`[YouTube] Ad detected (duration changed: ${state.youtube.videoDuration.toFixed(0)}s → ${currentDuration.toFixed(0)}s), skipping seek detection`)
+        state.youtube.lastPollTimestamp = Date.now()
+        return
+      }
+      // 広告終了後にdurationが戻った場合、記録を更新
+      if (currentDuration > 0 && state.youtube.videoDuration === 0) {
+        state.youtube.videoDuration = currentDuration
+      }
 
       const currentTime = youtubePlayer.getCurrentTime()
       const now = Date.now()
@@ -120,6 +138,12 @@ export default function youtubeStore(state, emitter) {
       const timeDiff = Math.abs(currentTime - expectedTime)
 
       if (timeDiff > SEEK_THRESHOLD) {
+        // 追加ガード: currentTimeが動画本編の範囲外なら広告の可能性が高い
+        if (state.youtube.videoDuration > 0 && currentTime > state.youtube.videoDuration) {
+          state.youtube.lastPolledTime = currentTime
+          state.youtube.lastPollTimestamp = now
+          return
+        }
         console.log(`[YouTube] Seek detected: ${expectedTime.toFixed(1)}s → ${currentTime.toFixed(1)}s (diff: ${timeDiff.toFixed(1)}s)`)
         emitter.emit('youtube: on user seek', currentTime)
       }


### PR DESCRIPTION
YouTube IFrame API has no native seek event, so this uses polling
(300ms interval) to detect time jumps > 2s. When detected, finds the
closest snapshot by youtubeTime and seeks Hydra's session playback.
Includes infinite loop prevention via ignoringSeek flag.

https://claude.ai/code/session_01UFYqSPtguEoBWHH6xsQinR