### PR TITLE
fix: セッション保存の失敗を握りつぶさず、録画バッファを失わないようにする

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -167,6 +167,19 @@ a:hover {
   font-size: 11px;
 }
 
+/* 保存/録画の失敗。saved と違いフェードアウトさせない */
+#recording-indicator.storage-error {
+  opacity: 1;
+}
+
+#recording-indicator .storage-error-message {
+  color: #fff;
+  background: #c00;
+  padding: 3px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
 @keyframes saved-fade {
   0%, 70% { opacity: 0.8; }
   100% { opacity: 0; }
@@ -354,6 +367,15 @@ a:hover {
   border-radius: 4px;
   cursor: pointer;
   margin-bottom: 4px;
+}
+
+/* 本体データが失われたセッション（再生・エクスポート不可） */
+.session-item.broken {
+  opacity: 0.45;
+}
+
+.session-item.broken .session-meta {
+  color: #f66;
 }
 
 .session-item:hover {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -180,6 +180,14 @@ a:hover {
   font-size: 11px;
 }
 
+/* 赤帯と同時に出る一時通知。赤帯より弱く見せて主従を付ける */
+#recording-indicator.storage-error .saved-message {
+  color: #ccc;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 3px 6px;
+  border-radius: 3px;
+}
+
 @keyframes saved-fade {
   0%, 70% { opacity: 0.8; }
   100% { opacity: 0; }

--- a/src/stores/performance-store.js
+++ b/src/stores/performance-store.js
@@ -6,7 +6,17 @@
 
 // ローカルストレージのキー
 const STORAGE_META_KEY = 'hydra_performance_meta'
-const STORAGE_SESSION_PREFIX = 'hydra_perf_'
+export const STORAGE_SESSION_PREFIX = 'hydra_perf_'
+
+// セッション本体が実在するか。getItem は存在確認のためだけに値全体（数MBに
+// なりうる）を文字列化するので、キーの有無だけ見たい場面ではこちらを使う。
+export function hasSessionBody(sessionId) {
+  try {
+    return Object.prototype.hasOwnProperty.call(localStorage, STORAGE_SESSION_PREFIX + sessionId)
+  } catch (e) {
+    return false
+  }
+}
 const AUTO_BUFFER_KEY = 'hydra_perf_autobuffer'
 
 // 録画バッファの書き込みが失敗している状態を表す表示文字列
@@ -149,7 +159,8 @@ export default function performanceStore(state, emitter) {
   // という意味が薄れて本物の警告に気づけなくなる。
   function showStorageError(message) {
     state.performance.storageError = message
-    state.performance.savedMessage = null
+    // savedMessageは消さない。「保存は成功したが録画の再開に失敗した」のように
+    // 両方が同時に真になる場合があり、インジケータは両方を並べて表示する。
     emitter.emit('render')
   }
 
@@ -183,11 +194,20 @@ export default function performanceStore(state, emitter) {
     }
     // ここで書けないと以降のcaptureSnapshotがバッファを読めず即returnするので、
     // 録画が始まっていないことがどこにも出ないまま一晩無記録になる。
-    if (!autoBuffer.save(buffer)) showStorageError(REC_ERROR)
+    const ok = autoBuffer.save(buffer)
     state.performance.autoBufferStartTime = now
     state.performance.snapshotCount = 0
     // 新規バッファでは最初のeditor全文を必ず記録できるよう重複排除をリセット
     lastEditorText = null
+    if (!ok) {
+      showStorageError(REC_ERROR)
+      return null
+    }
+    // 書けたなら録画は復旧している
+    if (state.performance.storageError === REC_ERROR) {
+      state.performance.storageError = false
+      emitter.emit('render')
+    }
     return buffer
   }
 
@@ -259,6 +279,10 @@ export default function performanceStore(state, emitter) {
     // durationを設定
     buffer.duration = Date.now() - state.performance.autoBufferStartTime
 
+    // resume したセッションは buffer.id が既存セッションと同じで、この保存は
+    // 上書き更新になる。その場合は本体を消してはいけないので先に控えておく。
+    const existedBefore = hasSessionBody(buffer.id)
+
     // 正式セッションとして保存。
     // bufferはautoBufferキーにも同じ内容が入っているので、そのまま書くと保存の
     // 瞬間だけ同じデータが2つ載り、ピーク使用量が倍になって容量超過を自分で
@@ -266,8 +290,13 @@ export default function performanceStore(state, emitter) {
     // (bufferはメモリ上にあるので、この間にデータが失われることはない)
     autoBuffer.clear()
     if (!storage.saveSession(buffer)) {
-      autoBuffer.save(buffer)
-      failSave('Save failed: storage full')
+      // clear() で空けた分と同じサイズを書くので通常は復元できるが、失敗すると
+      // bufferはこの return で失われる。案内が嘘にならないよう文面を分ける。
+      if (autoBuffer.save(buffer)) {
+        failSave('Save failed: storage full — buffer kept, free space and retry')
+      } else {
+        failSave('Save failed: storage full — recording buffer lost')
+      }
       return
     }
 
@@ -283,11 +312,22 @@ export default function performanceStore(state, emitter) {
     }
     meta.lastSessionId = buffer.id
     if (!storage.saveMeta(meta)) {
-      // メタが書けなければ本体は一覧に出ない孤児になる。容量だけ食うので巻き戻し、
-      // バッファも復元して再保存できる状態に戻す。
-      storage.deleteSession(buffer.id)
-      autoBuffer.save(buffer)
-      failSave('Save failed: storage full (meta)')
+      if (existedBefore) {
+        // resume の上書き保存。本体は書けていて meta にも既に載っているので、
+        // 本体が正しいデータ。ここでバッファを書き戻すと同じ内容が2つ載って
+        // 容量不足を悪化させるだけなので、録画は新しいバッファで続行する。
+        startAutoBuffer()
+        failSave('Save failed (meta) — session body is intact')
+      } else {
+        // 新規セッション。本体だけ残ると一覧に出ないまま容量を食うので巻き戻し、
+        // バッファを復元して再保存できる状態に戻す。
+        storage.deleteSession(buffer.id)
+        if (autoBuffer.save(buffer)) {
+          failSave('Save failed (meta) — buffer kept, free space and retry')
+        } else {
+          failSave('Save failed (meta) — recording buffer lost')
+        }
+      }
       return
     }
     state.performance.sessions = meta.sessions
@@ -325,13 +365,12 @@ export default function performanceStore(state, emitter) {
   function captureSnapshot(code) {
     if (!state.performance.autoBufferStartTime) return
 
-    const buffer = autoBuffer.get()
-    if (!buffer) {
-      // バッファの書き込みに失敗している（容量超過など）。黙って戻ると記録が
-      // 進んでいないことに気づけないので表示に出す。
-      if (state.performance.storageError !== REC_ERROR) showStorageError(REC_ERROR)
-      return
-    }
+    // バッファが書けずに失われている状態。ここで作り直さないと、赤い表示を見て
+    // 古いセッションを削除し容量を空けても、リロードするまで録画が再開しない
+    // （startAutoBufferに至る経路がDOMContentLoaded/保存成功/resumeしかないため）。
+    // 空きが戻っていればここで復旧し、まだ駄目ならstartAutoBuffer側が表示を出す。
+    const buffer = autoBuffer.get() || startAutoBuffer()
+    if (!buffer) return
 
     const timestamp = Date.now() - state.performance.autoBufferStartTime
     const now = performance.now()
@@ -392,10 +431,10 @@ export default function performanceStore(state, emitter) {
     // ここが黙って失敗するとライブ中ずっと記録が進んでいないことになるので、
     // 状態を変えたときだけ再描画して表示に出す。
     const saved = autoBuffer.save(buffer)
-    // 保存失敗(REC_ERROR以外)の表示は上書きしない。次のeval一発で消えると、
-    // セッションが保存できていないことに気づかないまま演奏を続けてしまう。
+    // 保存失敗(REC_ERROR以外)の表示は成功時も失敗時も上書きしない。次のeval一発で
+    // 消えると、セッションが保存できていないことに気づかないまま演奏を続けてしまう。
     const cur = state.performance.storageError
-    const nextError = saved ? (cur === REC_ERROR ? false : cur) : REC_ERROR
+    const nextError = saved ? (cur === REC_ERROR ? false : cur) : (cur || REC_ERROR)
     if (cur !== nextError) {
       state.performance.storageError = nextError
       emitter.emit('render')
@@ -924,7 +963,8 @@ export default function performanceStore(state, emitter) {
       snapshots: session.snapshots || [],
       youtube: session.youtube || null
     }
-    autoBuffer.save(buffer)
+    // 書けないと以降の録画が丸ごと落ちるので、resume でも成否を見る
+    if (!autoBuffer.save(buffer)) showStorageError(REC_ERROR)
     state.performance.autoBufferStartTime = now - existingDuration
     state.performance.snapshotCount = buffer.snapshots.length
     delete state.performance._pendingCodeCheck

--- a/src/stores/performance-store.js
+++ b/src/stores/performance-store.js
@@ -158,6 +158,8 @@ export default function performanceStore(state, emitter) {
   // だけに使う。ここに一時的な通知を混ぜると、赤帯が出ている＝録れていない、
   // という意味が薄れて本物の警告に気づけなくなる。
   function showStorageError(message) {
+    // 容量超過中は eval のたびに同じ失敗を通るので、変化が無ければ再描画しない
+    if (state.performance.storageError === message) return
     state.performance.storageError = message
     // savedMessageは消さない。「保存は成功したが録画の再開に失敗した」のように
     // 両方が同時に真になる場合があり、インジケータは両方を並べて表示する。
@@ -259,7 +261,9 @@ export default function performanceStore(state, emitter) {
   // いたため、セッションが無言で全損していた。失敗は消えない表示で知らせる。
   function failSave(message) {
     showStorageError(message)
-    console.error(`[Performance] ${message} — buffer kept, export & delete old sessions to free space`)
+    // 「バッファは残っている」等の後始末はケースごとに違うので、messageに含める。
+    // ここで一律のサフィックスを付けると、復元に失敗した場合に矛盾したログになる。
+    console.error(`[Performance] ${message}`)
   }
 
   // セッション保存（自動録画バッファを正式セッションに昇格）
@@ -311,13 +315,25 @@ export default function performanceStore(state, emitter) {
       preload: buffer.preload || null
     }
     meta.lastSessionId = buffer.id
-    if (!storage.saveMeta(meta)) {
+    let metaSaved = storage.saveMeta(meta)
+    let bufferRestarted = false
+
+    if (!metaSaved && existedBefore) {
+      // resume の上書き保存。本体は新しい内容で書けていて meta にも既に載っている
+      // ので、本体が正。バッファを書き戻すと同じ内容が2つ載って容量不足を悪化
+      // させるだけなので、新しいバッファで録画を続行する。
+      // その解放でバッファN個ぶんの空きが戻るため、metaをもう一度だけ試す。
+      startAutoBuffer()
+      bufferRestarted = true
+      metaSaved = storage.saveMeta(meta)
+    }
+
+    if (!metaSaved) {
       if (existedBefore) {
-        // resume の上書き保存。本体は書けていて meta にも既に載っているので、
-        // 本体が正しいデータ。ここでバッファを書き戻すと同じ内容が2つ載って
-        // 容量不足を悪化させるだけなので、録画は新しいバッファで続行する。
-        startAutoBuffer()
-        failSave('Save failed (meta) — session body is intact')
+        // 本体は新しい内容、metaは保存前の古い値のまま。一覧のsnapshotCount /
+        // duration / nameが実データと食い違うが、本体は存在するのでbroken判定には
+        // かからない。検知できない不整合なので文面で伝える。
+        failSave('Save failed (meta) — body saved, list info may be stale')
       } else {
         // 新規セッション。本体だけ残ると一覧に出ないまま容量を食うので巻き戻し、
         // バッファを復元して再保存できる状態に戻す。
@@ -330,8 +346,10 @@ export default function performanceStore(state, emitter) {
       }
       return
     }
+
     state.performance.sessions = meta.sessions
-    state.performance.storageError = false
+    // 録画自体が止まっている表示は消さない（保存の成否とは別の継続状態）
+    if (state.performance.storageError !== REC_ERROR) state.performance.storageError = false
 
     const snapshotCount = buffer.snapshots.length
     console.log(`[Performance] Session saved: ${buffer.id} (${snapshotCount} snapshots)`)
@@ -344,9 +362,11 @@ export default function performanceStore(state, emitter) {
       emitter.emit('render')
     }, 3000)
 
-    // 新しい自動録画バッファを開始
-    startAutoBuffer()
-    console.log('[Performance] New auto-recording started')
+    // 新しい自動録画バッファを開始（metaリトライ時に開始済みなら二重に作らない）
+    if (!bufferRestarted) {
+      startAutoBuffer()
+      console.log('[Performance] New auto-recording started')
+    }
   })
 
   // 後方互換: toggle recording → save session

--- a/src/stores/performance-store.js
+++ b/src/stores/performance-store.js
@@ -202,7 +202,10 @@ export default function performanceStore(state, emitter) {
     // 新規バッファでは最初のeditor全文を必ず記録できるよう重複排除をリセット
     lastEditorText = null
     if (!ok) {
-      showStorageError(REC_ERROR)
+      // 保存失敗の表示が出ているならそれを優先する（captureSnapshot側と同じ方針）。
+      // どちらも容量超過を示すが、より具体的な方を残す。
+      const cur = state.performance.storageError
+      if (!cur || cur === REC_ERROR) showStorageError(REC_ERROR)
       return null
     }
     // 書けたなら録画は復旧している
@@ -315,24 +318,17 @@ export default function performanceStore(state, emitter) {
       preload: buffer.preload || null
     }
     meta.lastSessionId = buffer.id
-    let metaSaved = storage.saveMeta(meta)
-    let bufferRestarted = false
-
-    if (!metaSaved && existedBefore) {
-      // resume の上書き保存。本体は新しい内容で書けていて meta にも既に載っている
-      // ので、本体が正。バッファを書き戻すと同じ内容が2つ載って容量不足を悪化
-      // させるだけなので、新しいバッファで録画を続行する。
-      // その解放でバッファN個ぶんの空きが戻るため、metaをもう一度だけ試す。
-      startAutoBuffer()
-      bufferRestarted = true
-      metaSaved = storage.saveMeta(meta)
-    }
-
-    if (!metaSaved) {
+    if (!storage.saveMeta(meta)) {
       if (existedBefore) {
-        // 本体は新しい内容、metaは保存前の古い値のまま。一覧のsnapshotCount /
-        // duration / nameが実データと食い違うが、本体は存在するのでbroken判定には
-        // かからない。検知できない不整合なので文面で伝える。
+        // resume の上書き保存。本体は新しい内容で書けていて meta にも既に載って
+        // いるので、本体が正。バッファを書き戻すと同じ内容が2つ載って容量不足を
+        // 悪化させるだけなので、新しいバッファで録画を続行する。
+        // ただし meta は保存前の古い値のまま残る。一覧の snapshotCount /
+        // duration / name が実データと食い違うが、本体は存在するので broken 判定
+        // には引っかからない。検知できない不整合なので文面で伝える。
+        // (ここで saveMeta を再試行しても無意味。autoBufferは上の clear() で既に
+        //  解放済みで、startAutoBuffer は空きを増やさず小さいバッファを足すだけ)
+        startAutoBuffer()
         failSave('Save failed (meta) — body saved, list info may be stale')
       } else {
         // 新規セッション。本体だけ残ると一覧に出ないまま容量を食うので巻き戻し、
@@ -362,11 +358,9 @@ export default function performanceStore(state, emitter) {
       emitter.emit('render')
     }, 3000)
 
-    // 新しい自動録画バッファを開始（metaリトライ時に開始済みなら二重に作らない）
-    if (!bufferRestarted) {
-      startAutoBuffer()
-      console.log('[Performance] New auto-recording started')
-    }
+    // 新しい自動録画バッファを開始
+    startAutoBuffer()
+    console.log('[Performance] New auto-recording started')
   })
 
   // 後方互換: toggle recording → save session

--- a/src/stores/performance-store.js
+++ b/src/stores/performance-store.js
@@ -9,6 +9,9 @@ const STORAGE_META_KEY = 'hydra_performance_meta'
 const STORAGE_SESSION_PREFIX = 'hydra_perf_'
 const AUTO_BUFFER_KEY = 'hydra_perf_autobuffer'
 
+// 録画バッファの書き込みが失敗している状態を表す表示文字列
+const REC_ERROR = 'Recording stopped: storage full'
+
 // UUID生成
 function generateUUID() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
@@ -37,11 +40,16 @@ const storage = {
     }
   },
 
+  // 書き込み系は成否を返す。localStorageは容量超過で黙って失敗しうるが、
+  // 呼び出し側がそれを知らずに先へ進むと「メタにあるのに本体が無い」壊れた
+  // セッションが出来上がるため、例外を握りつぶしたままにしない。
   saveMeta(meta) {
     try {
       localStorage.setItem(STORAGE_META_KEY, JSON.stringify(meta))
+      return true
     } catch (e) {
       console.error('Failed to save performance meta:', e)
+      return false
     }
   },
 
@@ -58,8 +66,10 @@ const storage = {
   saveSession(session) {
     try {
       localStorage.setItem(STORAGE_SESSION_PREFIX + session.id, JSON.stringify(session))
+      return true
     } catch (e) {
       console.error('Failed to save session:', e)
+      return false
     }
   },
 
@@ -87,8 +97,10 @@ const autoBuffer = {
   save(buffer) {
     try {
       localStorage.setItem(AUTO_BUFFER_KEY, JSON.stringify(buffer))
+      return true
     } catch (e) {
       console.error('Failed to save auto-buffer:', e)
+      return false
     }
   },
 
@@ -126,7 +138,31 @@ export default function performanceStore(state, emitter) {
 
     // セッションリストUI
     showSessionList: false,
-    editingSessionId: null
+    editingSessionId: null,
+
+    // localStorage書き込み失敗の表示（false or メッセージ文字列）
+    storageError: false
+  }
+
+  // 消えない失敗表示。「保存できていない」「録画が止まっている」という継続状態
+  // だけに使う。ここに一時的な通知を混ぜると、赤帯が出ている＝録れていない、
+  // という意味が薄れて本物の警告に気づけなくなる。
+  function showStorageError(message) {
+    state.performance.storageError = message
+    state.performance.savedMessage = null
+    emitter.emit('render')
+  }
+
+  // 一時的な通知（3秒で消える）。ボタンが無反応にしか見えないのを防ぐ用。
+  function showNotice(message) {
+    state.performance.savedMessage = message
+    emitter.emit('render')
+    setTimeout(() => {
+      if (state.performance.savedMessage === message) {
+        state.performance.savedMessage = null
+        emitter.emit('render')
+      }
+    }, 3000)
   }
 
   // 自動録画バッファを新規作成する内部関数
@@ -145,7 +181,9 @@ export default function performanceStore(state, emitter) {
         startTime: 0
       } : null
     }
-    autoBuffer.save(buffer)
+    // ここで書けないと以降のcaptureSnapshotがバッファを読めず即returnするので、
+    // 録画が始まっていないことがどこにも出ないまま一晩無記録になる。
+    if (!autoBuffer.save(buffer)) showStorageError(REC_ERROR)
     state.performance.autoBufferStartTime = now
     state.performance.snapshotCount = 0
     // 新規バッファでは最初のeditor全文を必ず記録できるよう重複排除をリセット
@@ -197,6 +235,13 @@ export default function performanceStore(state, emitter) {
     }
   })
 
+  // 保存失敗時の共通処理。従来は失敗しても "Saved" と出して録画バッファを捨てて
+  // いたため、セッションが無言で全損していた。失敗は消えない表示で知らせる。
+  function failSave(message) {
+    showStorageError(message)
+    console.error(`[Performance] ${message} — buffer kept, export & delete old sessions to free space`)
+  }
+
   // セッション保存（自動録画バッファを正式セッションに昇格）
   emitter.on('performance: save session', () => {
     const buffer = autoBuffer.get()
@@ -214,8 +259,17 @@ export default function performanceStore(state, emitter) {
     // durationを設定
     buffer.duration = Date.now() - state.performance.autoBufferStartTime
 
-    // 正式セッションとして保存
-    storage.saveSession(buffer)
+    // 正式セッションとして保存。
+    // bufferはautoBufferキーにも同じ内容が入っているので、そのまま書くと保存の
+    // 瞬間だけ同じデータが2つ載り、ピーク使用量が倍になって容量超過を自分で
+    // 引き起こす。先にautoBuffer側を解放してから書き、失敗したら書き戻す。
+    // (bufferはメモリ上にあるので、この間にデータが失われることはない)
+    autoBuffer.clear()
+    if (!storage.saveSession(buffer)) {
+      autoBuffer.save(buffer)
+      failSave('Save failed: storage full')
+      return
+    }
 
     // メタデータを更新
     const meta = storage.getMeta()
@@ -228,8 +282,16 @@ export default function performanceStore(state, emitter) {
       preload: buffer.preload || null
     }
     meta.lastSessionId = buffer.id
-    storage.saveMeta(meta)
+    if (!storage.saveMeta(meta)) {
+      // メタが書けなければ本体は一覧に出ない孤児になる。容量だけ食うので巻き戻し、
+      // バッファも復元して再保存できる状態に戻す。
+      storage.deleteSession(buffer.id)
+      autoBuffer.save(buffer)
+      failSave('Save failed: storage full (meta)')
+      return
+    }
     state.performance.sessions = meta.sessions
+    state.performance.storageError = false
 
     const snapshotCount = buffer.snapshots.length
     console.log(`[Performance] Session saved: ${buffer.id} (${snapshotCount} snapshots)`)
@@ -264,7 +326,12 @@ export default function performanceStore(state, emitter) {
     if (!state.performance.autoBufferStartTime) return
 
     const buffer = autoBuffer.get()
-    if (!buffer) return
+    if (!buffer) {
+      // バッファの書き込みに失敗している（容量超過など）。黙って戻ると記録が
+      // 進んでいないことに気づけないので表示に出す。
+      if (state.performance.storageError !== REC_ERROR) showStorageError(REC_ERROR)
+      return
+    }
 
     const timestamp = Date.now() - state.performance.autoBufferStartTime
     const now = performance.now()
@@ -322,7 +389,17 @@ export default function performanceStore(state, emitter) {
     }
 
     buffer.snapshots.push(snapshot)
-    autoBuffer.save(buffer)
+    // ここが黙って失敗するとライブ中ずっと記録が進んでいないことになるので、
+    // 状態を変えたときだけ再描画して表示に出す。
+    const saved = autoBuffer.save(buffer)
+    // 保存失敗(REC_ERROR以外)の表示は上書きしない。次のeval一発で消えると、
+    // セッションが保存できていないことに気づかないまま演奏を続けてしまう。
+    const cur = state.performance.storageError
+    const nextError = saved ? (cur === REC_ERROR ? false : cur) : REC_ERROR
+    if (cur !== nextError) {
+      state.performance.storageError = nextError
+      emitter.emit('render')
+    }
     state.performance.snapshotCount = buffer.snapshots.length
 
     console.log(`[Performance] Snapshot added: ${timestamp}ms, ${code ? 'code' : 'midi'}${midiEvents ? ` (${midiEvents.length} midi events)` : ''}, total: ${buffer.snapshots.length}`)
@@ -372,6 +449,7 @@ export default function performanceStore(state, emitter) {
     const session = storage.getSession(sessionId)
     if (!session || session.snapshots.length === 0) {
       console.warn(`[Performance] Session not found or empty: ${sessionId}`)
+      showNotice('⚠ Session data missing — cannot play')
       return
     }
 
@@ -831,6 +909,7 @@ export default function performanceStore(state, emitter) {
     const session = storage.getSession(sessionId)
     if (!session) {
       console.warn(`[Performance] Session not found: ${sessionId}`)
+      showNotice('⚠ Session data missing — cannot resume')
       return
     }
 
@@ -901,6 +980,7 @@ export default function performanceStore(state, emitter) {
     const session = storage.getSession(sessionId)
     if (!session) {
       console.warn(`[Performance] Session not found: ${sessionId}`)
+      showNotice('⚠ Session data missing — cannot export')
       return
     }
 

--- a/src/views/recording-indicator.js
+++ b/src/views/recording-indicator.js
@@ -3,6 +3,16 @@ import html from 'choo/html'
 export default function recordingIndicator(state, emit) {
   const perf = state.performance
 
+  // 保存/録画の失敗表示。savedMessageより優先し、自動では消さない
+  // （消えると気づかないまま録り続けてしまうため）
+  if (perf?.storageError) {
+    return html`
+      <div id="recording-indicator" class="storage-error">
+        <span class="storage-error-message">⚠ ${perf.storageError}</span>
+      </div>
+    `
+  }
+
   // 保存確認メッセージ表示
   if (perf?.savedMessage) {
     return html`

--- a/src/views/recording-indicator.js
+++ b/src/views/recording-indicator.js
@@ -3,21 +3,20 @@ import html from 'choo/html'
 export default function recordingIndicator(state, emit) {
   const perf = state.performance
 
-  // 保存/録画の失敗表示。savedMessageより優先し、自動では消さない
-  // （消えると気づかないまま録り続けてしまうため）
-  if (perf?.storageError) {
+  // 保存/録画の失敗表示と一時通知。
+  // 赤帯は自動では消さない（消えると気づかないまま録り続けてしまうため）が、
+  // 一時通知を握り潰してはいけない。通知が必要になるのは、まさに赤帯が
+  // 立っている状況（本体を失ったセッションを再生・エクスポートしようとした時）
+  // なので、片方だけ表示すると再生もエクスポートも無反応に見えてしまう。
+  if (perf?.storageError || perf?.savedMessage) {
     return html`
-      <div id="recording-indicator" class="storage-error">
-        <span class="storage-error-message">⚠ ${perf.storageError}</span>
-      </div>
-    `
-  }
-
-  // 保存確認メッセージ表示
-  if (perf?.savedMessage) {
-    return html`
-      <div id="recording-indicator" class="saved">
-        <span class="saved-message">${perf.savedMessage}</span>
+      <div id="recording-indicator" class="${perf.storageError ? 'storage-error' : 'saved'}">
+        ${perf.storageError
+          ? html`<span class="storage-error-message">⚠ ${perf.storageError}</span>`
+          : ''}
+        ${perf.savedMessage
+          ? html`<span class="saved-message">${perf.savedMessage}</span>`
+          : ''}
       </div>
     `
   }

--- a/src/views/session-list.js
+++ b/src/views/session-list.js
@@ -1,4 +1,5 @@
 import html from 'choo/html'
+import { hasSessionBody } from '../stores/performance-store.js'
 
 // 時間フォーマット (ms -> mm:ss)
 function formatDuration(ms) {
@@ -16,24 +17,16 @@ function formatDate(timestamp) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
-// メタにだけ残って本体が無いセッション。一覧では正常に見えるのに再生も
-// エクスポートも無反応になるため、行の時点で分かるようにする。
-function isBroken(sessionId) {
-  try {
-    return localStorage.getItem('hydra_perf_' + sessionId) === null
-  } catch (e) {
-    return false
-  }
-}
-
 export default function sessionList(state, emit) {
   if (!state.performance?.showSessionList) return html``
 
   const sessions = state.performance.sessions || {}
   const sessionArray = Object.values(sessions).sort((a, b) => b.createdAt - a.createdAt)
   const editingSessionId = state.performance.editingSessionId
-  // 再生中は50ms間隔でrenderが走るので、行ごとにlocalStorageを引かず1回で済ませる
-  const brokenIds = new Set(sessionArray.filter(s => isBroken(s.id)).map(s => s.id))
+  // メタにだけ残って本体が無いセッション（再生もエクスポートもできない）。
+  // 再生を始めてもリストは閉じないため、開いたままだと50ms間隔のprogress
+  // intervalでrenderが回る。hasSessionBodyは値を読まずキーの有無だけ見る。
+  const brokenIds = new Set(sessionArray.filter(s => !hasSessionBody(s.id)).map(s => s.id))
 
   const closeList = () => {
     emit('performance: hide session list')

--- a/src/views/session-list.js
+++ b/src/views/session-list.js
@@ -16,12 +16,24 @@ function formatDate(timestamp) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
+// メタにだけ残って本体が無いセッション。一覧では正常に見えるのに再生も
+// エクスポートも無反応になるため、行の時点で分かるようにする。
+function isBroken(sessionId) {
+  try {
+    return localStorage.getItem('hydra_perf_' + sessionId) === null
+  } catch (e) {
+    return false
+  }
+}
+
 export default function sessionList(state, emit) {
   if (!state.performance?.showSessionList) return html``
 
   const sessions = state.performance.sessions || {}
   const sessionArray = Object.values(sessions).sort((a, b) => b.createdAt - a.createdAt)
   const editingSessionId = state.performance.editingSessionId
+  // 再生中は50ms間隔でrenderが走るので、行ごとにlocalStorageを引かず1回で済ませる
+  const brokenIds = new Set(sessionArray.filter(s => isBroken(s.id)).map(s => s.id))
 
   const closeList = () => {
     emit('performance: hide session list')
@@ -108,12 +120,12 @@ export default function sessionList(state, emit) {
           ${sessionArray.length === 0
             ? html`<p class="no-sessions">No recorded sessions yet.<br>Press Ctrl+Shift+R to start recording.</p>`
             : sessionArray.map(session => html`
-              <div class="session-item">
+              <div class="session-item ${brokenIds.has(session.id) ? 'broken' : ''}">
                 <div class="session-info">
                   ${renderSessionName(session)}
                   <div class="session-meta">
                     ${formatDate(session.createdAt)} ·
-                    ${session.snapshotCount || 0} snapshots ·
+                    ${brokenIds.has(session.id) ? '⚠ data missing' : `${session.snapshotCount || 0} snapshots`} ·
                     ${formatDuration(session.duration)}${session.preload ? ` · 🎛 ${session.preload}` : ''}
                   </div>
                   <div class="session-id">${session.id}</div>


### PR DESCRIPTION
## 何が起きていたか

セッション一覧に出ているのに、**再生ボタンも download ボタンも押しても何も起きない**セッションができていた。実際に `2026-08-12_NightRainbow` (664 snapshots) が失われている。

調査したところ、localStorage 上で **メタデータには登録されているのに、セッション本体 `hydra_perf_<id>` が存在しない**状態だった。

```
lastSessionId : 5b010c49-8fae-419e-889b-446180a48530
meta says     : 664 snapshots
body key      : *** MISSING ***
```

再生とエクスポートは別機能に見えるが、どちらも入口で同じことをしている。

```js
const session = storage.getSession(sessionId)
if (!session) { console.warn(...); return }   // 画面には何も出ない
```

`getSession` が `null` を返すので、両方とも `console.warn` だけ出して無言で return する。ボタンが壊れているのではなく、**データが無いことが画面に出ていなかった**。

## なぜ本体が消えたか

`storage.saveSession` は例外を握りつぶしていた。

```js
saveSession(session) {
  try { localStorage.setItem(...) }
  catch (e) { console.error('Failed to save session:', e) }   // 失敗しても呼び出し側は成功だと思う
}
```

そして `performance: save session` は、その結果を確認せずに先へ進んでいた。

```js
storage.saveSession(buffer)   // ← 失敗
meta.sessions[buffer.id] = {...}
storage.saveMeta(meta)        // ← メタだけ書けてしまう（ゴースト完成）
state.performance.savedMessage = `Saved: ${n} snapshots`   // ← 成功したと表示
startAutoBuffer()             // ← 中で autoBuffer.clear()。元データを消す
```

**保存に失敗した直後に、唯一残っていた元データを削除していた。** ユーザーには「Saved: 664 snapshots」と表示されるので、失敗に気づく手段が一切なかった。

### 書き込みが失敗した理由

`saveSession` の時点で、同じ内容が localStorage 上に 2 つ載る。

- `hydra_perf_autobuffer` … 録画中のバッファ（`captureSnapshot` が snapshot のたびに全体を書き直す）
- `hydra_perf_<id>` … いま書こうとしている、その**完全なコピー**

ピーク使用量が `既存の全セッション + 2N` になり、上限を超えて `QuotaExceededError` になった。`clear()` で `N` が解放された後は再び書けるようになるため、**事後に調べると容量に余裕があるように見える**（実際、事故後の計測では 20 万文字の追加書き込みが成功する）。上限の正確な値は事後に再現できないが、`meta` あり・本体なしという状態を作れるコードパスは失敗した `setItem` しか存在しない（`deleteSession` の呼び出しは削除ハンドラ1箇所のみで、そこはメタも一緒に消す。`buffer` は `JSON.parse` 由来なので `stringify` も失敗しない）。

## 変更内容

### 1. 書き込みの成否を返す

`saveSession` / `saveMeta` / `autoBuffer.save` が `true`/`false` を返すようにした。

### 2. ピーク使用量を半減させ、失敗してもデータを残す

`buffer` はメモリ上にあるので、**先に autoBuffer 側を解放してから書き、失敗したら書き戻す**。

```js
autoBuffer.clear()
if (!storage.saveSession(buffer)) {
  autoBuffer.save(buffer)          // 書き戻すのでデータは失われない
  failSave('Save failed: storage full')
  return                           // メタは更新しない
}
```

これで `2N` が `N` になり、そもそも失敗しにくくなる。

### 3. 失敗時に状態を進めない

保存に失敗したら **メタを更新しない・「Saved」を出さない・`startAutoBuffer()` / `clear()` を呼ばない**。バッファが残るので、古いセッションを整理してから押し直せば保存できる。メタの書き込みに失敗した場合は本体を巻き戻す（一覧に出ないまま容量だけ食う逆パターンを防ぐ）。

### 4. 録画が止まったことを表示する

`startAutoBuffer` の書き込み失敗は、これまで REC_ERROR に到達できない唯一の経路だった。書けないと以降の `captureSnapshot` が `autoBuffer.get()` で `null` を受けて即 return するため、**一晩まるごと無記録**になりうる。両方の経路を検知して、消えない赤い表示を出すようにした。

赤い表示は「保存できていない」「録画が止まっている」という**継続状態専用**にしている。一時的な通知を混ぜると赤帯の意味が薄れて本物の警告に気づけなくなるため、下の 5 は 3 秒で消える通知として分けた。

### 5. 無反応なボタンをなくす

再生 / エクスポート / resume の「本体なし」を `console.warn` だけで終わらせず、画面に通知を出す。

### 6. 一覧で壊れた行が分かるようにする

本体を失ったセッションを `⚠ data missing` として薄く表示する。判定は render ごとに 1 回だけ行う（再生中は 50ms 間隔で render が走るため）。

## 検証状況

`npx vite build` が通ることは確認済み。**これは構文チェックにすぎない。**

この修正の本体は「保存に失敗してもバッファが残ること」なので、実証するには localStorage を上限まで埋めて保存を実行し、(1) 赤い表示が出る (2) `hydra_perf_autobuffer` に snapshots が残っている を確認する手順が必要。**未実施。**

## 影響範囲

既にゴースト化しているセッションは復元できない（失われた 664 snapshots も同様）。この PR 適用後は一覧で `⚠ data missing` と表示されるので、既存の × ボタンで削除できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
